### PR TITLE
ament_package: 0.17.3-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -355,7 +355,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.17.3-1
+      version: 0.17.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.17.3-2`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-dyn-gbp/ament_package-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.3`
- previous version for package: `0.17.3-1`